### PR TITLE
Add exclude directive for maybe-ASP-open rule

### DIFF
--- a/PHPCompatibilityMagento/ruleset.xml
+++ b/PHPCompatibilityMagento/ruleset.xml
@@ -14,6 +14,7 @@
     <rule ref="PHPCompatibility">
         <!-- https://github.com/magento/magento2/.... -->
         <!-- TODO: add Magento specific excludes with a link to the file in which they are contained. -->
+        <exclude name="PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound" />
     </rule>
 
     <!-- https://github.com/magento/magento2/blob/2.4-develop/composer.json -->

--- a/Test/MagentoTest.php
+++ b/Test/MagentoTest.php
@@ -8,3 +8,11 @@
  */
 
 // TODO: add a test for each polyfilled feature (violations for which are excluded via the ruleset).
+
+// Magento's template syntax uses <% and %> as a delimiter. These should not be confused with ASP open/close tags.
+// @see https://github.com/magento/magento2/blob/2.4.6/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml#L108-L109
+?>
+<script data-template="test" type="text/x-magento-template">
+  <div id="<%- data.id %>" class="file-row">
+  </div>
+</script>


### PR DESCRIPTION
This directive is currently being excluded individually in the Magento2 ruleset. Moving it here will allow us to use this ruleset instead of maintaining the main PHP Compatibility ruleset going forward.

https://github.com/magento/magento-coding-standard/blob/0f81833b28d6fc3d799986ebcfa7fee659927ff4/Magento2/ruleset.xml#L765-L766