### PR TITLE
Add PHP_CodeSniffer as development dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Install dependencies to make sure the PHPCS XSD file is available.
       - name: Install dependencies
-        run: composer install --no-dev --no-interaction --no-progress
+        run: composer install --no-interaction --no-progress
 
       - name: Setup xmllint
         run: |

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "phpcompatibility/phpcompatibility-paragonie" : "^1.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "squizlabs/php_codesniffer": "^3.7"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically."


### PR DESCRIPTION
This is required to successfully run the tests both locally and in GitHub Actions.