### PR TITLE
GH Actions: work around intermittent apt-get errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,15 @@ jobs:
       - name: Install dependencies
         run: composer install --no-dev --no-interaction --no-progress
 
-      - name: Setup xmllint
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libxml2-utils
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
 
       # Show violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher


### PR DESCRIPTION
Okay, so apparently, there is a long-standing bug in the Microsoft package deploy process which caused `apt-get update` to fail in the first half hour after Microsoft has deployed a package.

The failure looks like this:
```
E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
```

As this only happens intermittently (after a MS package deploy), the chance of running into this bug are slim, but guess what: today I ran into it.

This change to the workflow is intended to prevent the next person running into this issue from having to waste time on figuring this out.

By splitting the "Install xmllint" step into two steps: one doing the `apt-get update` and one doing the actual install and making the first step one which is allowed to `continue-on-error`, this issue should hopefully not crop up anymore.

Any errors in the `apt-get update` step will now be ignored and as most errors which could potentially come from that step are irrelevant for the rest of the job anyway, this is fine. If a relevant error would be surfaced, the next step (the xmllint install), will fail the job anyway.

Refs:
* https://github.com/actions/runner-images/issues/3410
* https://github.com/dotnet/core/issues/4167